### PR TITLE
Attempt to fix the arm64 issue (#241) for the variadic argument list.

### DIFF
--- a/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceClient+DynamicMethod.m
+++ b/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceClient+DynamicMethod.m
@@ -65,7 +65,7 @@
         [inv getArgument:&arg atIndex:(int)(i + 2)];
         [parameterList addObject:arg];
     }
-    [self dynamicWebServiceCallWithArguments:parameterList forInVocation:inv];
+    [self dynamicWebServiceCallWithArguments:parameterList forInvocation:inv];
 }
 
 /**


### PR DESCRIPTION
forwardInvocation is used instead of resolveInstanceMethod in the RFWebServiceClient (DynamicMethod). Also the dynamicWebServiceCall:... was replaced to avoid using va_args with - dynamicWebServiceCallWithArguments:forInvocation:

Additional testing is needed.
