### PR TITLE
Added the import of Foundation.h to .h files

### DIFF
--- a/Framework/ROADCore/ROADCore/Categories/NSArray+RFClassSearch.h
+++ b/Framework/ROADCore/ROADCore/Categories/NSArray+RFClassSearch.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADCore/ROADCore/Categories/NSArray+RFClassSearch.h
+++ b/Framework/ROADCore/ROADCore/Categories/NSArray+RFClassSearch.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 @interface NSArray (RFClassSearch)
 

--- a/Framework/ROADCore/ROADCore/Categories/NSArray+RFEmptyArrayChecks.h
+++ b/Framework/ROADCore/ROADCore/Categories/NSArray+RFEmptyArrayChecks.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 /**
  * Category to return array elements or nil, in case the specified index does not contain array element (out of range, or the array is empty).

--- a/Framework/ROADCore/ROADCore/Categories/NSArray+RFEmptyArrayChecks.h
+++ b/Framework/ROADCore/ROADCore/Categories/NSArray+RFEmptyArrayChecks.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADCore/ROADCore/Categories/NSDictionary+RFKeyedSubscript.h
+++ b/Framework/ROADCore/ROADCore/Categories/NSDictionary+RFKeyedSubscript.h
@@ -32,7 +32,7 @@
 
 
 #ifndef __IPHONE_6_0
-
+#import <Foundation/Foundation.h>
 
 /**
  * Category to extend keyed subscript for fetching elements in a dictionary prior to iOS 6.0.

--- a/Framework/ROADCore/ROADCore/Categories/NSMutableDictionary+RFKeyedSubscript.h
+++ b/Framework/ROADCore/ROADCore/Categories/NSMutableDictionary+RFKeyedSubscript.h
@@ -32,7 +32,7 @@
 
 
 #ifndef __IPHONE_6_0
-
+#import <Foundation/Foundation.h>
 
 /**
  * Category to allow keyed subscript support for mutable dictionaries to set elements.

--- a/Framework/ROADCore/ROADCore/Categories/NSMutableString+RFStringFormatter.h
+++ b/Framework/ROADCore/ROADCore/Categories/NSMutableString+RFStringFormatter.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 /**
  * Category enabling to substitude values into an url expression using key-value pairs.

--- a/Framework/ROADCore/ROADCore/Categories/NSMutableString+RFStringFormatter.h
+++ b/Framework/ROADCore/ROADCore/Categories/NSMutableString+RFStringFormatter.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 /**
  * Category enabling to substitude values into an url expression using key-value pairs.

--- a/Framework/ROADCore/ROADCore/Containers/RFDynamicObject.h
+++ b/Framework/ROADCore/ROADCore/Containers/RFDynamicObject.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 /**
  * A generic container object, prepared to accept all kind of values through KVC's valueForUndefinedKey: and setValue:forUndefinedKey: methods. Also supports dynamic method resolution for properties accessing these values

--- a/Framework/ROADCore/ROADCore/Containers/RFDynamicObject.h
+++ b/Framework/ROADCore/ROADCore/Containers/RFDynamicObject.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 /**
  * A generic container object, prepared to accept all kind of values through KVC's valueForUndefinedKey: and setValue:forUndefinedKey: methods. Also supports dynamic method resolution for properties accessing these values

--- a/Framework/ROADCore/ROADCore/Containers/RFObjectPool.h
+++ b/Framework/ROADCore/ROADCore/Containers/RFObjectPool.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 typedef id(^RFObjectPoolInitializerBlock)(id objectCreated, id identifier);
 

--- a/Framework/ROADCore/ROADCore/Containers/RFObjectPool.h
+++ b/Framework/ROADCore/ROADCore/Containers/RFObjectPool.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 typedef id(^RFObjectPoolInitializerBlock)(id objectCreated, id identifier);
 

--- a/Framework/ROADSerialization/ROADSerialization/Assistants/RFSerializationAssistant.h
+++ b/Framework/ROADSerialization/ROADSerialization/Assistants/RFSerializationAssistant.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFSerializationCustomHandler.h"
 

--- a/Framework/ROADSerialization/ROADSerialization/Assistants/RFSerializationAssistant.h
+++ b/Framework/ROADSerialization/ROADSerialization/Assistants/RFSerializationAssistant.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFSerializationCustomHandler.h"
 
 @class RFPropertyInfo;

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFDerived.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFDerived.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFDerived.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFDerived.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializable.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializable.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializable.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializable.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableBoolean.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableBoolean.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableBoolean.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableBoolean.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableCollection.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableCollection.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableCollection.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableCollection.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableDate.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableDate.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableDate.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializableDate.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializationCustomHandler.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializationCustomHandler.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializationCustomHandler.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFSerializationCustomHandler.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFXMLSerializable.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFXMLSerializable.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFSerializable.h"
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFXMLSerializable.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFXMLSerializable.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFSerializable.h"
 
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFXMLSerializableCollection.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFXMLSerializableCollection.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFSerializableCollection.h"
 

--- a/Framework/ROADSerialization/ROADSerialization/Attributes/RFXMLSerializableCollection.h
+++ b/Framework/ROADSerialization/ROADSerialization/Attributes/RFXMLSerializableCollection.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFSerializableCollection.h"
 
 

--- a/Framework/ROADSerialization/ROADSerialization/Categories/NSJSONSerialization+RFJSONStringHandling.h
+++ b/Framework/ROADSerialization/ROADSerialization/Categories/NSJSONSerialization+RFJSONStringHandling.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 /**
  * Convenience methods to return JSON dictionary from strings.

--- a/Framework/ROADSerialization/ROADSerialization/Categories/NSJSONSerialization+RFJSONStringHandling.h
+++ b/Framework/ROADSerialization/ROADSerialization/Categories/NSJSONSerialization+RFJSONStringHandling.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 /**
  * Convenience methods to return JSON dictionary from strings.

--- a/Framework/ROADSerialization/ROADSerialization/JSON/RFAttributedCoder.h
+++ b/Framework/ROADSerialization/ROADSerialization/JSON/RFAttributedCoder.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 
 /**
  JSON serializer. This class is using the RFSerializable and RFDerived attributes to map the memory objects to JSON strings.

--- a/Framework/ROADSerialization/ROADSerialization/JSON/RFAttributedCoder.h
+++ b/Framework/ROADSerialization/ROADSerialization/JSON/RFAttributedCoder.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 /**
  JSON serializer. This class is using the RFSerializable and RFDerived attributes to map the memory objects to JSON strings.

--- a/Framework/ROADSerialization/ROADSerialization/JSON/RFAttributedDecoder.h
+++ b/Framework/ROADSerialization/ROADSerialization/JSON/RFAttributedDecoder.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 /**
  * JSON deserializer. This class is using the RFSerializable and RFDerived attributes to map the JSON string to memory objects.

--- a/Framework/ROADSerialization/ROADSerialization/JSON/RFAttributedDecoder.h
+++ b/Framework/ROADSerialization/ROADSerialization/JSON/RFAttributedDecoder.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 /**
  * JSON deserializer. This class is using the RFSerializable and RFDerived attributes to map the JSON string to memory objects.

--- a/Framework/ROADSerialization/ROADSerialization/JSON/RFJSONSerializationHandling.h
+++ b/Framework/ROADSerialization/ROADSerialization/JSON/RFJSONSerializationHandling.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 /**
  * Defines methods that you need to implement in order to use class as custom serialization handler.

--- a/Framework/ROADSerialization/ROADSerialization/JSON/RFJSONSerializationHandling.h
+++ b/Framework/ROADSerialization/ROADSerialization/JSON/RFJSONSerializationHandling.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 /**
  * Defines methods that you need to implement in order to use class as custom serialization handler.

--- a/Framework/ROADSerialization/ROADSerialization/XML/Internal/RFXMLSerializationContext.h
+++ b/Framework/ROADSerialization/ROADSerialization/XML/Internal/RFXMLSerializationContext.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 @class RFPropertyInfo;
 

--- a/Framework/ROADSerialization/ROADSerialization/XML/Internal/RFXMLSerializationContext.h
+++ b/Framework/ROADSerialization/ROADSerialization/XML/Internal/RFXMLSerializationContext.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 @class RFPropertyInfo;
 

--- a/Framework/ROADSerialization/ROADSerialization/XML/RFAttributedXMLCoder.h
+++ b/Framework/ROADSerialization/ROADSerialization/XML/RFAttributedXMLCoder.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 @interface RFAttributedXMLCoder : NSObject
 

--- a/Framework/ROADSerialization/ROADSerialization/XML/RFAttributedXMLCoder.h
+++ b/Framework/ROADSerialization/ROADSerialization/XML/RFAttributedXMLCoder.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 @interface RFAttributedXMLCoder : NSObject
 

--- a/Framework/ROADSerialization/ROADSerialization/XML/RFAttributedXMLDecoder.h
+++ b/Framework/ROADSerialization/ROADSerialization/XML/RFAttributedXMLDecoder.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 @interface RFAttributedXMLDecoder : NSObject
 

--- a/Framework/ROADSerialization/ROADSerialization/XML/RFAttributedXMLDecoder.h
+++ b/Framework/ROADSerialization/ROADSerialization/XML/RFAttributedXMLDecoder.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 @interface RFAttributedXMLDecoder : NSObject
 

--- a/Framework/ROADServices/ROADServices/Attributes/RFService.h
+++ b/Framework/ROADServices/ROADServices/Attributes/RFService.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADServices/ROADServices/Attributes/RFService.h
+++ b/Framework/ROADServices/ROADServices/Attributes/RFService.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 /**

--- a/Framework/ROADServices/ROADServices/Service/RFServiceProvider.h
+++ b/Framework/ROADServices/ROADServices/Service/RFServiceProvider.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFService.h"
 
 

--- a/Framework/ROADServices/ROADServices/Service/RFServiceProvider.h
+++ b/Framework/ROADServices/ROADServices/Service/RFServiceProvider.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFService.h"
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFMultipartData.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFMultipartData.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFMultipartData.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFMultipartData.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebService.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebService.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebService.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebService.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceCache.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceCache.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 /**
  * The attribute override default behaviour of caching mechanism by specifying cached record expiration date or disabling caching.

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceCache.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceCache.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceCall.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceCall.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceCall.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceCall.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceClientStatusCodes.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceClientStatusCodes.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceClientStatusCodes.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceClientStatusCodes.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceErrorHandler.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceErrorHandler.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceErrorHandler.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceErrorHandler.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceHeader.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceHeader.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceHeader.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceHeader.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceSerializer.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceSerializer.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceSerializer.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceSerializer.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceURLBuilder.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceURLBuilder.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceURLBuilder.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceURLBuilder.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceURLBuilderParameter.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceURLBuilderParameter.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceURLBuilderParameter.h
+++ b/Framework/ROADWebService/ROADWebService/Attributes/RFWebServiceURLBuilderParameter.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFAuthenticating.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFAuthenticating.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 @class RFWebServiceClient;
 @protocol RFWebServiceCancellable;

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFAuthenticating.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFAuthenticating.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFAuthenticationProvider.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFAuthenticationProvider.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFAuthenticating.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFAuthenticationProvider.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFAuthenticationProvider.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFAuthenticating.h"
 

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFBasicAuthenticationProvider.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFBasicAuthenticationProvider.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFAuthenticationProvider.h"
 

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFBasicAuthenticationProvider.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFBasicAuthenticationProvider.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFAuthenticationProvider.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFConcurrentAuthenticationProvider.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFConcurrentAuthenticationProvider.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFAuthenticationProvider.h"
 

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFConcurrentAuthenticationProvider.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFConcurrentAuthenticationProvider.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFAuthenticationProvider.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFDigestAuthenticationProvider.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFDigestAuthenticationProvider.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFBasicAuthenticationProvider.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFDigestAuthenticationProvider.h
+++ b/Framework/ROADWebService/ROADWebService/AuthenticationProvider/RFDigestAuthenticationProvider.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFBasicAuthenticationProvider.h"
 

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebResponse+HTTPResponse.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebResponse+HTTPResponse.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFWebResponse.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebResponse+HTTPResponse.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebResponse+HTTPResponse.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFWebResponse.h"
 

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebResponse.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebResponse.h
@@ -30,8 +30,10 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
+
 
 @interface RFWebResponseImplementation : NSObject<NSCoding>
 

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebResponse.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebResponse.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
 
 @interface RFWebResponseImplementation : NSObject<NSCoding>

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCacheContext.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCacheContext.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCacheContext.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCacheContext.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
 

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCachingManager.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCachingManager.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFWebServiceCachingManaging.h"
 

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCachingManager.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCachingManager.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFWebServiceCachingManaging.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCachingManaging.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCachingManaging.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 @class RFWebResponse;
 @class RFWebServiceCache;

--- a/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCachingManaging.h
+++ b/Framework/ROADWebService/ROADWebService/Caching/RFWebServiceCachingManaging.h
@@ -30,7 +30,9 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
 
 @class RFWebResponse;
 @class RFWebServiceCache;

--- a/Framework/ROADWebService/ROADWebService/Categories/NSError+RFWebService.h
+++ b/Framework/ROADWebService/ROADWebService/Categories/NSError+RFWebService.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 extern NSString * const kRFWebServiceErrorDomain;
 extern NSString * const kRFWebServiceRecievedDataKey;

--- a/Framework/ROADWebService/ROADWebService/Categories/NSError+RFWebService.h
+++ b/Framework/ROADWebService/ROADWebService/Categories/NSError+RFWebService.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 extern NSString * const kRFWebServiceErrorDomain;

--- a/Framework/ROADWebService/ROADWebService/OData/Attributes/RFODataEntity.h
+++ b/Framework/ROADWebService/ROADWebService/OData/Attributes/RFODataEntity.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/OData/Attributes/RFODataEntity.h
+++ b/Framework/ROADWebService/ROADWebService/OData/Attributes/RFODataEntity.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/OData/Attributes/RFODataProperty.h
+++ b/Framework/ROADWebService/ROADWebService/OData/Attributes/RFODataProperty.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/OData/Attributes/RFODataProperty.h
+++ b/Framework/ROADWebService/ROADWebService/OData/Attributes/RFODataProperty.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADAttribute.h>
 

--- a/Framework/ROADWebService/ROADWebService/OData/NSSortDescriptor+RFOData.h
+++ b/Framework/ROADWebService/ROADWebService/OData/NSSortDescriptor+RFOData.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/OData/NSSortDescriptor+RFOData.h
+++ b/Framework/ROADWebService/ROADWebService/OData/NSSortDescriptor+RFOData.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 @class RFPropertyInfo;
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataAbstractEntity.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataAbstractEntity.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataAbstractEntity.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataAbstractEntity.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 @interface RFODataAbstractEntity : NSObject
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataErrorHandler.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataErrorHandler.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFWebServiceErrorHandling.h"
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataErrorHandler.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataErrorHandler.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFWebServiceErrorHandling.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataExpression.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataExpression.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADReflection.h>
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataExpression.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataExpression.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADReflection.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataFetchRequest.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataFetchRequest.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFODataPrioritizedPredicate.h"
 #import "RFODataExpression.h"
 #import "NSSortDescriptor+RFOData.h"

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataFetchRequest.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataFetchRequest.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFODataPrioritizedPredicate.h"
 #import "RFODataExpression.h"

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataPredicate.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataPredicate.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 @class RFODataExpression;

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataPredicate.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataPredicate.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
 
 @class RFODataExpression;
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataPrioritizedPredicate.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataPrioritizedPredicate.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFODataPredicate.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataPrioritizedPredicate.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataPrioritizedPredicate.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFODataPredicate.h"
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataWebServiceURLBuilder.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataWebServiceURLBuilder.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFWebServiceBasicURLBuilder.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/OData/RFODataWebServiceURLBuilder.h
+++ b/Framework/ROADWebService/ROADWebService/OData/RFODataWebServiceURLBuilder.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFWebServiceBasicURLBuilder.h"
 

--- a/Framework/ROADWebService/ROADWebService/Private/Downloader/RFDownloader.h
+++ b/Framework/ROADWebService/ROADWebService/Private/Downloader/RFDownloader.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFWebServiceCancellable.h"
 #import "RFWebServiceClient.h"
 

--- a/Framework/ROADWebService/ROADWebService/Private/Downloader/RFDownloader.h
+++ b/Framework/ROADWebService/ROADWebService/Private/Downloader/RFDownloader.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFWebServiceCancellable.h"
 #import "RFWebServiceClient.h"

--- a/Framework/ROADWebService/ROADWebService/Private/Downloader/RFLooper.h
+++ b/Framework/ROADWebService/ROADWebService/Private/Downloader/RFLooper.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 @interface RFLooper : NSObject
 

--- a/Framework/ROADWebService/ROADWebService/Private/Downloader/RFLooper.h
+++ b/Framework/ROADWebService/ROADWebService/Private/Downloader/RFLooper.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceBasicURLBuilder.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceBasicURLBuilder.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFWebServiceURLBuilding.h"
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceBasicURLBuilder.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceBasicURLBuilder.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFWebServiceURLBuilding.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceCallParameterEncoder.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceCallParameterEncoder.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceCallParameterEncoder.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceCallParameterEncoder.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 @protocol RFSerializationDelegate;
 @class RFWebServiceClient;

--- a/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceSerializationHandler.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceSerializationHandler.h
@@ -30,7 +30,10 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
+
+
 @protocol RFSerializationDelegate;
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceSerializationHandler.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/Private/RFWebServiceSerializationHandler.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 @protocol RFSerializationDelegate;
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFDefaultSerializer.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFDefaultSerializer.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFSerializationDelegate.h"
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFDefaultSerializer.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFDefaultSerializer.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFSerializationDelegate.h"
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFFormData.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFFormData.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 @interface RFFormData : NSObject
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFFormData.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFFormData.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFSerializationDelegate.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFSerializationDelegate.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFSerializationDelegate.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFSerializationDelegate.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 /**
  * The serialization delegate for the webservice call.

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceCancellable.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceCancellable.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 /**
  * The cancellable protocol. It has to be implemented if one of the call shoulb be cancellable.

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceCancellable.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceCancellable.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceClient.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceClient.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import <ROAD/ROADServices.h>
 
 extern NSString * const kRFWebServiceClientArrayKey;

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceClient.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceClient.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import <ROAD/ROADServices.h>
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceErrorHandling.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceErrorHandling.h
@@ -31,6 +31,9 @@
 //  for additional information regarding copyright ownership and licensing
 
 
+#import <Foundation/Foundation.h>
+
+
 @protocol RFWebServiceErrorHandling <NSObject>
 
 /**

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceRequestProcessing.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceRequestProcessing.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Epam Systems. All rights reserved.
 //
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceRequestProcessing.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceRequestProcessing.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2014 Epam Systems. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
 
 @protocol RFWebServiceRequestProcessing <NSObject>
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceURLBuilding.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceURLBuilding.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceURLBuilding.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFWebServiceURLBuilding.h
@@ -30,6 +30,8 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+#import <Foundation/Foundation.h>
+
 
 @class RFWebServiceURLBuilder;
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFXMLSerializer.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFXMLSerializer.h
@@ -30,6 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
+
 #import <Foundation/Foundation.h>
 #import "RFSerializationDelegate.h"
 

--- a/Framework/ROADWebService/ROADWebService/Webservice/RFXMLSerializer.h
+++ b/Framework/ROADWebService/ROADWebService/Webservice/RFXMLSerializer.h
@@ -30,7 +30,7 @@
 //  See the NOTICE file and the LICENSE file distributed with this work
 //  for additional information regarding copyright ownership and licensing
 
-
+#import <Foundation/Foundation.h>
 #import "RFSerializationDelegate.h"
 
 


### PR DESCRIPTION
Xcode 6 doesn't create .pch file by default so there isn't the import of Foundation. The empty projects with ROAD pod don't work. Also you can delete .pch file from iTunes example project and the project will not run.